### PR TITLE
Add another forbidden pattern

### DIFF
--- a/config/ratel/patterns.yml
+++ b/config/ratel/patterns.yml
@@ -102,3 +102,4 @@ patterns:
   - lovepetsz
   - petklove
   - promocoes
+  - ilm


### PR DESCRIPTION
Com a migração do subdominio da loja do Instituto Luisa Mell de "ilm.petlove" para "icaramelo.petlove", criamos um redirect do subdominio "ilm" para o novo "icaramelo.petlove". 
Com isso, não queremos que sejam criados novas lojas com o subdominio "ilm"